### PR TITLE
Add .gitignore for static site project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# Editor
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Claude
+.claude/


### PR DESCRIPTION
Ignores OS files, editor directories, and the .claude worktree directory.